### PR TITLE
Removed :path from options

### DIFF
--- a/lib/paperclip-s3.rb
+++ b/lib/paperclip-s3.rb
@@ -19,7 +19,6 @@ module Paperclip
       def has_attached_file(name, options = {})
         s3_protocol = !!ENV["S3_PROTOCOL"] ? ENV["S3_PROTOCOL"] : "http"
         options[:storage] = :s3
-        options[:path]    ||= "/:class/:attachment/:id_partition/:style/:filename"
         options[:bucket]  ||= ENV["S3_BUCKET"]
         options[:s3_protocol] ||= s3_protocol
         options[:s3_credentials] ||= {


### PR DESCRIPTION
Setting the `:path` option means that we assume that a recent version of Paperclip is in use.

Is this line really necessary ? Shouldn't Paperclip already set this option ? In my case, `:path` option is set from `paperclip_defaults` in `application.rb` but it was ignored in production because of this line. So removing it worked for me.
